### PR TITLE
Allow enums to be rendered using dropdowns

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -21,11 +21,18 @@ Parameters:
   EventBridgeEnabled:
     Type: String
     Default: 'false'
-    Description: Whether to enable EventBridge. Default is false. Acceptable values [true, false].
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Description: Whether the tracker should emit EventBridge events.
   TrackerPositionFilteringType:
     Type: String
     Default: 'TimeBased'
-    Description: Tracker's filtering type. Default is TimeBased. See Amazon Location Tracking documentation for details.
+    AllowedValues:
+      - TimeBased
+      - DistanceBased
+      - AccuracyBased
+    Description: The tracker's position filtering configuration. See Amazon Location Tracking documentation for details.
   KinesisStreamArn:
     Type: String
     Description: ARN of your Kinesis data stream for tracking data.


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Enumerates potential values using `AllowedValues` to improve ergonomics (by rendering options as a dropdown) when deploying using the AWS Console.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
